### PR TITLE
[Feat] 운영중인 스터디 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/join/core/attendance/repository/AttendanceQueryRepository.java
+++ b/src/main/java/com/join/core/attendance/repository/AttendanceQueryRepository.java
@@ -7,4 +7,15 @@ import java.util.List;
 
 public interface AttendanceQueryRepository {
     List<Attendance> findAttendancesByAvatarIdAndEnrollmentStatuses(Long avatarId, List<EnrollmentStatus> statuses);
+
+    List<Attendance> findAttendancesByStudyIdInEnrollmentStatuses(
+            Long studyId,
+            List<EnrollmentStatus> statuses
+    );
+
+    List<Attendance> findAttendancesByAvatarIdAndStudyIdInEnrollmentStatuses(
+            Long avatarId,
+            Long studyId,
+            List<EnrollmentStatus> statuses
+    );
 }

--- a/src/main/java/com/join/core/attendance/repository/AttendanceQueryRepositoryImpl.java
+++ b/src/main/java/com/join/core/attendance/repository/AttendanceQueryRepositoryImpl.java
@@ -1,17 +1,19 @@
 package com.join.core.attendance.repository;
 
 import com.join.core.attendance.domain.Attendance;
-import com.join.core.attendance.domain.QAttendance;
 import com.join.core.enrollment.constant.EnrollmentStatus;
-import com.join.core.enrollment.domain.QEnrollment;
-import com.join.core.meeting.domain.QMeeting;
-import com.join.core.study.domain.QStudy;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+
+import static com.join.core.attendance.domain.QAttendance.*;
+import static com.join.core.avatar.domain.QAvatar.*;
+import static com.join.core.enrollment.domain.QEnrollment.*;
+import static com.join.core.meeting.domain.QMeeting.*;
+import static com.join.core.study.domain.QStudy.*;
 
 @RequiredArgsConstructor
 @Component
@@ -21,26 +23,56 @@ public class AttendanceQueryRepositoryImpl implements AttendanceQueryRepository 
 
     @Override
     public List<Attendance> findAttendancesByAvatarIdAndEnrollmentStatuses(Long avatarId, List<EnrollmentStatus> statuses) {
-        QAttendance attendance = QAttendance.attendance;
-        QMeeting meeting = QMeeting.meeting;
-        QStudy study = QStudy.study;
-        QEnrollment enrollment = QEnrollment.enrollment;
-
         return queryFactory
                 .selectFrom(attendance)
                 .distinct()
                 .join(attendance.meeting, meeting)
                 .join(meeting.study, study)
                 .where(
-                        study.id.in(
-                                JPAExpressions
-                                        .select(enrollment.study.id)
-                                        .from(enrollment)
-                                        .where(
-                                                enrollment.avatar.id.eq(avatarId)
-                                                        .and(enrollment.status.in(statuses))
-                                        )
-                        )
+                        JPAExpressions
+                                .selectOne()
+                                .from(enrollment)
+                                .where(
+                                        enrollment.study.id.eq(study.id)
+                                                .and(enrollment.avatar.id.eq(avatarId))
+                                                .and(enrollment.status.in(statuses))
+                                )
+                                .exists(),
+                        attendance.avatar.id.eq(avatarId)
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<Attendance> findAttendancesByStudyIdInEnrollmentStatuses(Long studyId, List<EnrollmentStatus> statuses) {
+        return queryFactory
+                .selectFrom(attendance)
+                .join(attendance.meeting, meeting)
+                .join(attendance.avatar, avatar)
+                .join(meeting.study, study).on(study.id.eq(studyId))
+                .leftJoin(enrollment).on(
+                        enrollment.study.eq(study)
+                                .and(enrollment.avatar.eq(avatar))
+                )
+                .where(
+                        enrollment.status.in(statuses)
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<Attendance> findAttendancesByAvatarIdAndStudyIdInEnrollmentStatuses(Long avatarId, Long studyId, List<EnrollmentStatus> statuses) {
+        return queryFactory
+                .selectFrom(attendance)
+                .join(attendance.meeting, meeting)
+                .join(attendance.avatar, avatar).on(avatar.id.eq(avatarId))
+                .join(meeting.study, study).on(study.id.eq(studyId))
+                .leftJoin(enrollment).on(
+                        enrollment.study.eq(study)
+                                .and(enrollment.avatar.eq(avatar))
+                )
+                .where(
+                        enrollment.status.in(statuses)
                 )
                 .fetch();
     }

--- a/src/main/java/com/join/core/attendance/repository/AttendanceReaderImpl.java
+++ b/src/main/java/com/join/core/attendance/repository/AttendanceReaderImpl.java
@@ -36,4 +36,23 @@ public class AttendanceReaderImpl implements AttendanceReader {
         return attendanceQueryRepository.findAttendancesByAvatarIdAndEnrollmentStatuses(avatarId, List.of(EnrollmentStatus.LEFT));
     }
 
+    @Override
+    public List<Attendance> findByStudyIdForJoinedStudy(Long studyId) {
+        return attendanceQueryRepository.findAttendancesByStudyIdInEnrollmentStatuses(studyId, List.of(EnrollmentStatus.JOINED, EnrollmentStatus.REQUEST_LEAVE));
+    }
+
+    @Override
+    public List<Attendance> findByStudyIdForLeftStudy(Long studyId) {
+        return attendanceQueryRepository.findAttendancesByStudyIdInEnrollmentStatuses(studyId, List.of(EnrollmentStatus.LEFT));
+    }
+
+    @Override
+    public List<Attendance> findByAvatarIdAndStudyIdForJoinedStudy(Long avatarId, Long studyId) {
+        return attendanceQueryRepository.findAttendancesByAvatarIdAndStudyIdInEnrollmentStatuses(avatarId, studyId, List.of(EnrollmentStatus.JOINED, EnrollmentStatus.REQUEST_LEAVE));
+    }
+
+    @Override
+    public List<Attendance> findByAvatarIdAndStudyIdForLeftStudy(Long avatarId, Long studyId) {
+        return attendanceQueryRepository.findAttendancesByAvatarIdAndStudyIdInEnrollmentStatuses(avatarId, studyId, List.of(EnrollmentStatus.LEFT));
+    }
 }

--- a/src/main/java/com/join/core/attendance/service/AttendanceRateService.java
+++ b/src/main/java/com/join/core/attendance/service/AttendanceRateService.java
@@ -1,6 +1,7 @@
 package com.join.core.attendance.service;
 
 import com.join.core.attendance.domain.Attendance;
+import com.join.core.common.util.NumberUtil;
 import com.join.core.enrollment.constant.EnrollmentStatus;
 import com.join.core.meeting.domain.MeetingReader;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ public class AttendanceRateService {
     private final MeetingReader meetingReader;
 
     @Transactional(readOnly = true)
-    public double calculateAttendanceRate(Long avatarId) {
+    public double calculateIndividualAttendanceRate(Long avatarId) {
         List<Attendance> attendancesForJoinedStudies = attendanceReader.findAttendanceForJoinedStudy(avatarId);
         List<Attendance> attendancesForLeftStudies = attendanceReader.findAttendanceForLeftStudy(avatarId);
 
@@ -41,6 +42,7 @@ public class AttendanceRateService {
 
         if (totalAttendance == 0) return 0.0;
 
-        return totalAttendance / totalMeetings * 100;
+        return NumberUtil.round(2, totalAttendance / totalMeetings * 100);
+    }
     }
 }

--- a/src/main/java/com/join/core/attendance/service/AttendanceRateService.java
+++ b/src/main/java/com/join/core/attendance/service/AttendanceRateService.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class AttendanceRateService {
 
+    private final AvatarReader avatarReader;
     private final AttendanceReader attendanceReader;
     private final MeetingReader meetingReader;
 
@@ -51,7 +52,7 @@ public class AttendanceRateService {
         List<Attendance> attendancesForJoinedStudies = attendanceReader.findByStudyIdForJoinedStudy(studyId);
         List<Attendance> attendancesForLeftStudies = attendanceReader.findByStudyIdForLeftStudy(studyId);
 
-        long countStudyMembers = avatarReader.findAvatarsExceptLeftByStudyId(studyId).size();
+        long countStudyMembers = avatarReader.findAvatarsExceptPendingByStudyId(studyId).size();
         long countAllMeetings = meetingReader.findMeetingsByStudyId(studyId).size();
         long totalMeetings = countAllMeetings * countStudyMembers;
 

--- a/src/main/java/com/join/core/attendance/service/AttendanceRateService.java
+++ b/src/main/java/com/join/core/attendance/service/AttendanceRateService.java
@@ -1,6 +1,7 @@
 package com.join.core.attendance.service;
 
 import com.join.core.attendance.domain.Attendance;
+import com.join.core.avatar.domain.AvatarReader;
 import com.join.core.common.util.NumberUtil;
 import com.join.core.enrollment.constant.EnrollmentStatus;
 import com.join.core.meeting.domain.MeetingReader;
@@ -44,5 +45,60 @@ public class AttendanceRateService {
 
         return NumberUtil.round(2, totalAttendance / totalMeetings * 100);
     }
+
+    @Transactional(readOnly = true)
+    public double calculateTeamAttendanceRateForStudy(Long studyId) {
+        List<Attendance> attendancesForJoinedStudies = attendanceReader.findByStudyIdForJoinedStudy(studyId);
+        List<Attendance> attendancesForLeftStudies = attendanceReader.findByStudyIdForLeftStudy(studyId);
+
+        long countStudyMembers = avatarReader.findAvatarsExceptLeftByStudyId(studyId).size();
+        long countAllMeetings = meetingReader.findMeetingsByStudyId(studyId).size();
+        long totalMeetings = countAllMeetings * countStudyMembers;
+
+        double totalAttendance = Stream.concat(
+                        attendancesForJoinedStudies.stream(),
+                        attendancesForLeftStudies.stream()
+                )
+                .mapToDouble(attendance -> {
+                    double reflectionRate = attendance.getStatus().getReflectionRate();
+
+                    if (attendancesForLeftStudies.contains(attendance)) {
+                        reflectionRate *= EnrollmentStatus.LEFT.getReflectionRate();
+                    }
+
+                    return reflectionRate;
+                })
+                .sum();
+
+        if (totalAttendance == 0) return 0.0;
+
+        return NumberUtil.round(2, totalAttendance / totalMeetings * 100);
+    }
+
+    @Transactional(readOnly = true)
+    public double calculateMemberAttendanceRateForStudy(Long avatarId, Long studyId) {
+        List<Attendance> attendancesForJoinedStudies = attendanceReader.findByAvatarIdAndStudyIdForJoinedStudy(avatarId, studyId);
+        List<Attendance> attendancesForLeftStudies = attendanceReader.findByAvatarIdAndStudyIdForLeftStudy(avatarId, studyId);
+
+        long totalMeetings = meetingReader.findMeetingsByStudyId(studyId).size();
+
+        double totalAttendance = Stream.concat(
+                        attendancesForJoinedStudies.stream(),
+                        attendancesForLeftStudies.stream()
+                )
+                .mapToDouble(attendance -> {
+                    double reflectionRate = attendance.getStatus().getReflectionRate();
+
+                    if (attendancesForLeftStudies.contains(attendance)) {
+                        reflectionRate *= EnrollmentStatus.LEFT.getReflectionRate();
+                    }
+
+                    return reflectionRate;
+                })
+                .sum();
+
+        if (totalAttendance == 0) return 0.0;
+
+        return NumberUtil.round(2, totalAttendance / totalMeetings * 100);
     }
 }

--- a/src/main/java/com/join/core/attendance/service/AttendanceReader.java
+++ b/src/main/java/com/join/core/attendance/service/AttendanceReader.java
@@ -14,4 +14,12 @@ public interface AttendanceReader {
     List<Attendance> findAttendanceForJoinedStudy(Long avatarId);
 
     List<Attendance> findAttendanceForLeftStudy(Long avatarId);
+
+    List<Attendance> findByStudyIdForJoinedStudy(Long studyId);
+
+    List<Attendance> findByStudyIdForLeftStudy(Long studyId);
+
+    List<Attendance> findByAvatarIdAndStudyIdForJoinedStudy(Long avatarId, Long studyId);
+
+    List<Attendance> findByAvatarIdAndStudyIdForLeftStudy(Long avatarId, Long studyId);
 }

--- a/src/main/java/com/join/core/avatar/controller/MyPageController.java
+++ b/src/main/java/com/join/core/avatar/controller/MyPageController.java
@@ -3,6 +3,7 @@ package com.join.core.avatar.controller;
 import com.join.core.auth.domain.UserPrincipal;
 import com.join.core.avatar.controller.specification.MyPageControllerSpecification;
 import com.join.core.avatar.domain.MyPageService;
+import com.join.core.avatar.dto.response.MyManagedStudyInfoResponse;
 import com.join.core.avatar.dto.response.MyPageInfoResponse;
 import com.join.core.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -24,5 +27,12 @@ public class MyPageController implements MyPageControllerSpecification {
     public ApiResponse<MyPageInfoResponse> getMyPageInfo(
 			@AuthenticationPrincipal UserPrincipal principal) {
         return ApiResponse.ok(myPageService.getMyPageInfo(principal.getAvatarId()));
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/manage-study")
+    public ApiResponse<List<MyManagedStudyInfoResponse>> getMyManagedStudies(
+            @AuthenticationPrincipal UserPrincipal principal) {
+        return ApiResponse.ok(myPageService.getMyManagedStudies(principal.getAvatarId()));
     }
 }

--- a/src/main/java/com/join/core/avatar/controller/specification/MyPageControllerSpecification.java
+++ b/src/main/java/com/join/core/avatar/controller/specification/MyPageControllerSpecification.java
@@ -1,12 +1,15 @@
 package com.join.core.avatar.controller.specification;
 
 import com.join.core.auth.domain.UserPrincipal;
+import com.join.core.avatar.dto.response.MyManagedStudyInfoResponse;
 import com.join.core.avatar.dto.response.MyPageInfoResponse;
 import com.join.core.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.util.List;
 
 public interface MyPageControllerSpecification {
 
@@ -15,5 +18,12 @@ public interface MyPageControllerSpecification {
             description = "마이페이지 조회",
             security = {@SecurityRequirement(name = "session-token")})
     ApiResponse<MyPageInfoResponse> getMyPageInfo(
+            @AuthenticationPrincipal UserPrincipal principal);
+
+    @Tag(name = "${swagger.tag.user}")
+    @Operation(summary = "마이페이지 운영중인 스터디 목록 조회 - 인증 필수",
+            description = "마이페이지 운영중인 스터디 목록을 조회해옵니다.",
+            security = {@SecurityRequirement(name = "session-token")})
+    ApiResponse<List<MyManagedStudyInfoResponse>> getMyManagedStudies(
             @AuthenticationPrincipal UserPrincipal principal);
 }

--- a/src/main/java/com/join/core/avatar/controller/specification/MyPageControllerSpecification.java
+++ b/src/main/java/com/join/core/avatar/controller/specification/MyPageControllerSpecification.java
@@ -13,14 +13,14 @@ import java.util.List;
 
 public interface MyPageControllerSpecification {
 
-    @Tag(name = "${swagger.tag.user}")
+    @Tag(name = "${swagger.tag.my-page}")
     @Operation(summary = "마이페이지 조회 - 인증 필수",
             description = "마이페이지 조회",
             security = {@SecurityRequirement(name = "session-token")})
     ApiResponse<MyPageInfoResponse> getMyPageInfo(
             @AuthenticationPrincipal UserPrincipal principal);
 
-    @Tag(name = "${swagger.tag.user}")
+    @Tag(name = "${swagger.tag.my-page}")
     @Operation(summary = "마이페이지 운영중인 스터디 목록 조회 - 인증 필수",
             description = "마이페이지 운영중인 스터디 목록을 조회해옵니다.",
             security = {@SecurityRequirement(name = "session-token")})

--- a/src/main/java/com/join/core/avatar/domain/AvatarReader.java
+++ b/src/main/java/com/join/core/avatar/domain/AvatarReader.java
@@ -1,5 +1,7 @@
 package com.join.core.avatar.domain;
 
+import java.util.List;
+
 public interface AvatarReader {
 	Avatar getAvatarById(Long avatarId);
 
@@ -11,4 +13,5 @@ public interface AvatarReader {
 
 	Avatar getAvatarByAvatarToken(String avatarToken);
 
+	List<Avatar> findAvatarsExceptPendingByStudyId(Long studyId);
 }

--- a/src/main/java/com/join/core/avatar/domain/MyPageService.java
+++ b/src/main/java/com/join/core/avatar/domain/MyPageService.java
@@ -1,8 +1,12 @@
 package com.join.core.avatar.domain;
 
+import com.join.core.avatar.dto.response.MyManagedStudyInfoResponse;
 import com.join.core.avatar.dto.response.MyPageInfoResponse;
+
+import java.util.List;
 
 public interface MyPageService {
 
 	MyPageInfoResponse getMyPageInfo(Long avatarId);
+	List<MyManagedStudyInfoResponse> getMyManagedStudies(Long avatarId);
 }

--- a/src/main/java/com/join/core/avatar/domain/MyPageServiceImpl.java
+++ b/src/main/java/com/join/core/avatar/domain/MyPageServiceImpl.java
@@ -21,9 +21,9 @@ public class MyPageServiceImpl implements MyPageService {
     public MyPageInfoResponse getMyPageInfo(Long avatarId) {
         Avatar avatar = avatarReader.getAvatarById(avatarId);
 
-        double averageAttendanceRate = attendanceRateService.calculateAttendanceRate(avatarId);
+        double averageAttendanceRate = attendanceRateService.calculateIndividualAttendanceRate(avatarId);
 
-        double averageProofRate = proofRateService.calculateProofRate(avatarId);
+        double averageProofRate = proofRateService.calculateIndividualProofRate(avatarId);
 
         return MyPageInfoResponse.of(avatar, averageAttendanceRate, averageProofRate);
     }

--- a/src/main/java/com/join/core/avatar/domain/MyPageServiceImpl.java
+++ b/src/main/java/com/join/core/avatar/domain/MyPageServiceImpl.java
@@ -1,11 +1,17 @@
 package com.join.core.avatar.domain;
 
 import com.join.core.attendance.service.AttendanceRateService;
+import com.join.core.avatar.dto.response.MyManagedStudyInfoResponse;
 import com.join.core.avatar.dto.response.MyPageInfoResponse;
 import com.join.core.proof.service.ProofRateService;
+import com.join.core.proof.service.ProofReader;
+import com.join.core.study.domain.Study;
+import com.join.core.study.service.StudyReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -13,7 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class MyPageServiceImpl implements MyPageService {
 
     private final AvatarReader avatarReader;
+    private final StudyReader studyReader;
     private final AttendanceRateService attendanceRateService;
+    private final ProofReader proofReader;
     private final ProofRateService proofRateService;
 
     @Transactional(readOnly = true)
@@ -26,5 +34,32 @@ public class MyPageServiceImpl implements MyPageService {
         double averageProofRate = proofRateService.calculateIndividualProofRate(avatarId);
 
         return MyPageInfoResponse.of(avatar, averageAttendanceRate, averageProofRate);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<MyManagedStudyInfoResponse> getMyManagedStudies(Long avatarId) {
+        List<Study> managedStudies = studyReader.getStudiesByLeaderAvatarId(avatarId);
+
+        return managedStudies.stream().map(
+                study -> {
+                    double teamAttendanceRateForStudy = attendanceRateService.calculateTeamAttendanceRateForStudy(study.getId());
+                    double teamProofRateForStudy = proofRateService.calculateTeamAttendanceRateForStudy(study.getId());
+                    List<MyManagedStudyInfoResponse.StudyMemberAchievementDto> achievementDtos = getMembersRatesAndApprovedStatus(study);
+
+                    return MyManagedStudyInfoResponse.of(study, teamAttendanceRateForStudy, teamProofRateForStudy, achievementDtos);
+                }
+        ).toList();
+    }
+
+    private List<MyManagedStudyInfoResponse.StudyMemberAchievementDto> getMembersRatesAndApprovedStatus(Study study) {
+        List<Avatar> avatars = avatarReader.findAvatarsExceptPendingByStudyId(study.getId());
+        return avatars.stream()
+                .map(avatar -> {
+                    double attendanceRate = attendanceRateService.calculateMemberAttendanceRateForStudy(avatar.getId(), study.getId());
+                    double proofRate = proofRateService.calculateMembersAttendanceRateForStudy(avatar.getId(), study.getId());
+                    boolean isFullyApproved = proofReader.isFullyApproved(avatar.getId(), study.getId());
+                    return MyManagedStudyInfoResponse.StudyMemberAchievementDto.of(avatar, attendanceRate, proofRate, isFullyApproved);
+                }).toList();
     }
 }

--- a/src/main/java/com/join/core/avatar/dto/response/MyManagedStudyInfoResponse.java
+++ b/src/main/java/com/join/core/avatar/dto/response/MyManagedStudyInfoResponse.java
@@ -1,0 +1,58 @@
+package com.join.core.avatar.dto.response;
+
+import com.join.core.avatar.domain.Avatar;
+import com.join.core.study.constant.StudyStatus;
+import com.join.core.study.domain.Study;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record MyManagedStudyInfoResponse(
+        @Schema(description = "스터디 이름", example = "직장인 영어 회화 스터디")
+        String name,
+        @Schema(description = "모집 상태", example = "RECRUITING, READY, ACTIVE, COMPLETED 중 하나(모집중, 모집완료, 활동중, 활동완료)")
+        StudyStatus status,
+        @Schema(description = "평균 출결률", example = "56.25")
+        double teamAverageAttendanceRate,
+        @Schema(description = "평균 인증률", example = "56.25")
+        double teamAverageProofRate,
+        @Schema(description = "스터디원 별 평균 출결율, 인증률 및 모든 인증 승인 여부 리스트")
+        List<StudyMemberAchievementDto> studyMembersInfos,
+        @Schema(description = "스터디 카카오톡 링크", example = "https://open.kakao.com/o/joinjoinjoin")
+        String kakaoUrl
+) {
+    public record StudyMemberAchievementDto(
+            @Schema(description = "스터디원 아바타 토큰", example = "token")
+            String avatarToken,
+            @Schema(description = "스터디원 별명", example = "닉네임")
+            String nickname,
+            @Schema(description = "이 스터디에서의 평균 출석률", example = "87.5")
+            double averageAttendanceRate,
+            @Schema(description = "이 스터디에서의 평균 인증률", example = "87.5")
+            double averageProofRate,
+            @Schema(description = "이 스터디의 모든 인증이 승인되었는지에 대한 여부", example = "true")
+            boolean isFullyApproved
+    ) {
+
+        public static StudyMemberAchievementDto of(Avatar avatar, double averageAttendanceRate, double averageProofRate, boolean isFullyVerified) {
+            return new StudyMemberAchievementDto(
+                    avatar.getAvatarToken(),
+                    avatar.getNickname(),
+                    averageAttendanceRate,
+                    averageProofRate,
+                    isFullyVerified
+            );
+        }
+    }
+
+    public static MyManagedStudyInfoResponse of(Study study, double teamAverageAttendanceRate, double teamAverageProofRate, List<StudyMemberAchievementDto> achievementDtos) {
+        return new MyManagedStudyInfoResponse(
+                study.getStudyName(),
+                study.getStatus(),
+                teamAverageAttendanceRate,
+                teamAverageProofRate,
+                achievementDtos,
+                study.getKakaoUrl()
+        );
+    }
+}

--- a/src/main/java/com/join/core/avatar/repository/AvatarReaderImpl.java
+++ b/src/main/java/com/join/core/avatar/repository/AvatarReaderImpl.java
@@ -1,14 +1,17 @@
 package com.join.core.avatar.repository;
 
+import com.join.core.avatar.domain.Avatar;
 import com.join.core.avatar.domain.AvatarInfo;
 import com.join.core.avatar.domain.AvatarInfoMapper;
 import com.join.core.avatar.domain.AvatarReader;
-import com.join.core.avatar.domain.Avatar;
 import com.join.core.common.exception.ErrorCode;
 import com.join.core.common.exception.impl.EntityNotFoundException;
+import com.join.core.enrollment.repository.EnrollmentQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Repository
@@ -16,6 +19,7 @@ public class AvatarReaderImpl implements AvatarReader {
 
     private final AvatarRepository avatarRepository;
     private final AvatarInfoMapper avatarInfoMapper;
+    private final EnrollmentQueryRepository enrollmentQueryRepository;
 
     @Override
     public Avatar getAvatarById(Long id) {
@@ -47,4 +51,9 @@ public class AvatarReaderImpl implements AvatarReader {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.AVATAR_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public List<Avatar> findAvatarsExceptPendingByStudyId(Long studyId) {
+        return enrollmentQueryRepository.findAvatarsExceptPendingByStudyId(studyId);
+    }
 }

--- a/src/main/java/com/join/core/common/util/NumberUtil.java
+++ b/src/main/java/com/join/core/common/util/NumberUtil.java
@@ -1,0 +1,10 @@
+package com.join.core.common.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class NumberUtil {
+    public static double round(int newScale, double value) {
+        return BigDecimal.valueOf(value).setScale(newScale, RoundingMode.HALF_UP).doubleValue();
+    }
+}

--- a/src/main/java/com/join/core/enrollment/repository/EnrollmentQueryRepository.java
+++ b/src/main/java/com/join/core/enrollment/repository/EnrollmentQueryRepository.java
@@ -2,8 +2,11 @@ package com.join.core.enrollment.repository;
 
 import com.join.core.avatar.domain.Avatar;
 
+import java.util.List;
+
 public interface EnrollmentQueryRepository {
 
     Double getMemberAverageByStudyId(Long studyId);
     Avatar getLeaderByStudyId(Long studyId);
+    List<Avatar> findAvatarsExceptPendingByStudyId(Long studyId);
 }

--- a/src/main/java/com/join/core/enrollment/repository/EnrollmentQueryRepositoryImpl.java
+++ b/src/main/java/com/join/core/enrollment/repository/EnrollmentQueryRepositoryImpl.java
@@ -7,7 +7,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import static com.join.core.enrollment.domain.QEnrollment.enrollment;
+import java.util.List;
+
+import static com.join.core.enrollment.domain.QEnrollment.*;
 
 @RequiredArgsConstructor
 @Repository
@@ -39,5 +41,17 @@ public class EnrollmentQueryRepositoryImpl implements EnrollmentQueryRepository 
                         enrollment.status.eq(EnrollmentStatus.JOINED)
                 )
                 .fetchOne();
+    }
+
+    @Override
+    public List<Avatar> findAvatarsExceptPendingByStudyId(Long studyId) {
+        return queryFactory
+                .select(enrollment.avatar)
+                .from(enrollment)
+                .where(
+                        enrollment.study.id.eq(studyId),
+                        enrollment.status.in(EnrollmentStatus.JOINED, EnrollmentStatus.LEFT, EnrollmentStatus.REQUEST_LEAVE)
+                )
+                .fetch();
     }
 }

--- a/src/main/java/com/join/core/meeting/domain/MeetingReader.java
+++ b/src/main/java/com/join/core/meeting/domain/MeetingReader.java
@@ -9,4 +9,5 @@ public interface MeetingReader {
     Meeting getMeetingById(Long meetingId);
     Meeting findByStudyIdAndMeetingNo(Long studyId, int meetingNo);
     List<Meeting> findMeetingsByAvatarIdForStudies(Long avatarId);
+    List<Meeting> findMeetingsByStudyId(Long studyId);
 }

--- a/src/main/java/com/join/core/meeting/repository/MeetingQueryRepository.java
+++ b/src/main/java/com/join/core/meeting/repository/MeetingQueryRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface MeetingQueryRepository {
 
     List<Meeting> findMeetingsByAvatarIdAndEnrollmentStatuses(Long avatarId, List<EnrollmentStatus> statuses);
+    List<Meeting> findMeetingsByStudyId(Long studyId);
 }

--- a/src/main/java/com/join/core/meeting/repository/MeetingQueryRepositoryImpl.java
+++ b/src/main/java/com/join/core/meeting/repository/MeetingQueryRepositoryImpl.java
@@ -37,4 +37,15 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepository {
                 )
                 .fetch();
     }
+
+    @Override
+    public List<Meeting> findMeetingsByStudyId(Long studyId) {
+        return queryFactory
+                .selectFrom(meeting)
+                .join(meeting.study, study)
+                .where(
+                        study.id.eq(studyId)
+                )
+                .fetch();
+    }
 }

--- a/src/main/java/com/join/core/meeting/repository/MeetingQueryRepositoryImpl.java
+++ b/src/main/java/com/join/core/meeting/repository/MeetingQueryRepositoryImpl.java
@@ -1,10 +1,7 @@
 package com.join.core.meeting.repository;
 
 import com.join.core.enrollment.constant.EnrollmentStatus;
-import com.join.core.enrollment.domain.QEnrollment;
 import com.join.core.meeting.domain.Meeting;
-import com.join.core.meeting.domain.QMeeting;
-import com.join.core.study.domain.QStudy;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -12,17 +9,18 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static com.join.core.enrollment.domain.QEnrollment.*;
+import static com.join.core.meeting.domain.QMeeting.*;
+import static com.join.core.study.domain.QStudy.*;
+
 @RequiredArgsConstructor
 @Component
 public class MeetingQueryRepositoryImpl implements MeetingQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+
     @Override
     public List<Meeting> findMeetingsByAvatarIdAndEnrollmentStatuses(Long avatarId, List<EnrollmentStatus> statuses) {
-        QEnrollment enrollment = QEnrollment.enrollment;
-        QMeeting meeting = QMeeting.meeting;
-        QStudy study = QStudy.study;
-
         return queryFactory
                 .selectFrom(meeting)
                 .join(meeting.study, study)

--- a/src/main/java/com/join/core/meeting/repository/MeetingReaderImpl.java
+++ b/src/main/java/com/join/core/meeting/repository/MeetingReaderImpl.java
@@ -43,4 +43,9 @@ public class MeetingReaderImpl implements MeetingReader {
 
         return Stream.concat(meetingsForJoinedStudies.stream(), meetingsForLeftStudies.stream()).toList();
     }
+
+    @Override
+    public List<Meeting> findMeetingsByStudyId(Long studyId) {
+        return meetingQueryRepository.findMeetingsByStudyId(studyId);
+    }
 }

--- a/src/main/java/com/join/core/proof/repository/ProofQueryRepository.java
+++ b/src/main/java/com/join/core/proof/repository/ProofQueryRepository.java
@@ -7,4 +7,7 @@ import java.util.List;
 
 public interface ProofQueryRepository {
     List<Proof> findProofsByAvatarIdAndEnrollmentStatus(Long avatarId, List<EnrollmentStatus> statuses);
+    List<Proof> findProofsByStudyIdInEnrollmentStatuses(Long studyId, List<EnrollmentStatus> statuses);
+    List<Proof> findByAvatarIdAndStudyIdInEnrollmentStatuses(Long avatarId, Long studyId, List<EnrollmentStatus> statuses);
+    boolean allProofsHaveApprovedStatus(Long avatarId, Long studyId);
 }

--- a/src/main/java/com/join/core/proof/repository/ProofQueryRepositoryImpl.java
+++ b/src/main/java/com/join/core/proof/repository/ProofQueryRepositoryImpl.java
@@ -1,17 +1,20 @@
 package com.join.core.proof.repository;
 
 import com.join.core.enrollment.constant.EnrollmentStatus;
-import com.join.core.enrollment.domain.QEnrollment;
-import com.join.core.meeting.domain.QMeeting;
+import com.join.core.proof.constant.ProofStatus;
 import com.join.core.proof.domain.Proof;
-import com.join.core.proof.domain.QProof;
-import com.join.core.study.domain.QStudy;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+
+import static com.join.core.avatar.domain.QAvatar.*;
+import static com.join.core.enrollment.domain.QEnrollment.*;
+import static com.join.core.meeting.domain.QMeeting.*;
+import static com.join.core.proof.domain.QProof.*;
+import static com.join.core.study.domain.QStudy.*;
 
 @RequiredArgsConstructor
 @Component
@@ -21,27 +24,70 @@ public class ProofQueryRepositoryImpl implements ProofQueryRepository {
 
     @Override
     public List<Proof> findProofsByAvatarIdAndEnrollmentStatus(Long avatarId, List<EnrollmentStatus> statuses) {
-        QProof proof = QProof.proof;
-        QMeeting meeting = QMeeting.meeting;
-        QStudy study = QStudy.study;
-        QEnrollment enrollment = QEnrollment.enrollment;
-
         return queryFactory
                 .selectFrom(proof)
                 .distinct()
                 .join(proof.meeting, meeting)
                 .join(meeting.study, study)
                 .where(
-                        study.id.in(
-                                JPAExpressions
-                                        .select(enrollment.study.id)
-                                        .from(enrollment)
-                                        .where(
-                                                enrollment.avatar.id.eq(avatarId)
-                                                        .and(enrollment.status.in(statuses))
-                                        )
-                        )
+                        JPAExpressions
+                                .selectOne()
+                                .from(enrollment)
+                                .where(
+                                        enrollment.study.id.eq(study.id)
+                                                .and(enrollment.avatar.id.eq(avatarId))
+                                                .and(enrollment.status.in(statuses))
+                                )
+                                .exists(),
+                        proof.avatar.id.eq(avatarId)
                 )
                 .fetch();
+    }
+
+    @Override
+    public List<Proof> findProofsByStudyIdInEnrollmentStatuses(Long studyId, List<EnrollmentStatus> statuses) {
+        return queryFactory
+                .selectFrom(proof)
+                .join(proof.meeting, meeting)
+                .join(proof.avatar, avatar)
+                .join(meeting.study, study).on(study.id.eq(studyId))
+                .leftJoin(enrollment).on(
+                        enrollment.study.eq(study)
+                                .and(enrollment.avatar.eq(avatar))
+                )
+                .where(
+                        enrollment.status.in(statuses)
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<Proof> findByAvatarIdAndStudyIdInEnrollmentStatuses(Long avatarId, Long studyId, List<EnrollmentStatus> statuses) {
+        return queryFactory
+                .selectFrom(proof)
+                .join(proof.avatar, avatar).on(proof.avatar.id.eq(avatarId))
+                .join(proof.meeting, meeting)
+                .join(meeting.study, study).on(study.id.eq(studyId))
+                .leftJoin(enrollment).on(
+                        enrollment.study.eq(study)
+                                .and(enrollment.avatar.eq(avatar)))
+                .where(enrollment.status.in(statuses))
+                .fetch();
+    }
+
+    @Override
+    public boolean allProofsHaveApprovedStatus(Long avatarId, Long studyId) {
+        Long countNonApproved = queryFactory
+                .select(proof.count())
+                .from(proof)
+                .join(avatar).on(proof.avatar.id.eq(avatarId))
+                .join(meeting).on(proof.meeting.id.eq(meeting.id))
+                .join(study).on(study.id.eq(studyId))
+                .where(
+                        proof.status.ne(ProofStatus.APPROVED)
+                )
+                .fetchOne();
+
+        return countNonApproved == null || countNonApproved == 0;
     }
 }

--- a/src/main/java/com/join/core/proof/repository/ProofReaderImpl.java
+++ b/src/main/java/com/join/core/proof/repository/ProofReaderImpl.java
@@ -45,4 +45,29 @@ public class ProofReaderImpl implements ProofReader {
         return proofRepository.findById(proofId)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PROOF_ID));
     }
+
+    @Override
+    public List<Proof> findByStudyIdForJoinedStudy(Long studyId) {
+        return proofQueryRepository.findProofsByStudyIdInEnrollmentStatuses(studyId, List.of(EnrollmentStatus.JOINED, EnrollmentStatus.REQUEST_LEAVE));
+    }
+
+    @Override
+    public List<Proof> findByStudyIdForLeftStudy(Long studyId) {
+        return proofQueryRepository.findProofsByStudyIdInEnrollmentStatuses(studyId, List.of(EnrollmentStatus.LEFT));
+    }
+
+    @Override
+    public List<Proof> findByAvatarIdAndStudyIdForJoinedStudy(Long avatarId, Long studyId) {
+        return proofQueryRepository.findByAvatarIdAndStudyIdInEnrollmentStatuses(avatarId, studyId, List.of(EnrollmentStatus.JOINED, EnrollmentStatus.REQUEST_LEAVE));
+    }
+
+    @Override
+    public List<Proof> findByAvatarIdAndStudyIdForLeftStudy(Long avatarId, Long studyId) {
+        return proofQueryRepository.findByAvatarIdAndStudyIdInEnrollmentStatuses(avatarId, studyId, List.of(EnrollmentStatus.LEFT));
+    }
+
+    @Override
+    public boolean isFullyApproved(Long avatarId, Long studyId) {
+        return proofQueryRepository.allProofsHaveApprovedStatus(avatarId, studyId);
+    }
 }

--- a/src/main/java/com/join/core/proof/service/ProofRateService.java
+++ b/src/main/java/com/join/core/proof/service/ProofRateService.java
@@ -1,5 +1,6 @@
 package com.join.core.proof.service;
 
+import com.join.core.avatar.domain.AvatarReader;
 import com.join.core.common.util.NumberUtil;
 import com.join.core.enrollment.constant.EnrollmentStatus;
 import com.join.core.meeting.domain.MeetingReader;
@@ -15,6 +16,7 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class ProofRateService {
 
+    private final AvatarReader avatarReader;
     private final MeetingReader meetingReader;
     private final ProofReader proofReader;
 
@@ -46,5 +48,62 @@ public class ProofRateService {
 
         return NumberUtil.round(2, totalProof / totalMeetings * 100);
     }
+
+    @Transactional(readOnly = true)
+    public double calculateTeamAttendanceRateForStudy(Long studyId) {
+        List<Proof> attendancesForJoinedStudies = proofReader.findByStudyIdForJoinedStudy(studyId);
+        List<Proof> attendancesForLeftStudies = proofReader.findByStudyIdForLeftStudy(studyId);
+
+        long countStudyMembers = avatarReader.findAvatarsExceptPendingByStudyId(studyId).size();
+        long countMeetings = meetingReader.findMeetingsByStudyId(studyId).size();
+        long totalMeetings = countMeetings * countStudyMembers;
+
+        double totalAttendance = Stream.concat(
+                        attendancesForJoinedStudies.stream(),
+                        attendancesForLeftStudies.stream()
+                )
+                .mapToDouble(attendance -> {
+                    double reflectionRate = attendance.getStatus().getReflectionRate();
+
+                    if (attendancesForLeftStudies.contains(attendance)) {
+                        reflectionRate *= EnrollmentStatus.LEFT.getReflectionRate();
+                    }
+
+                    return reflectionRate;
+                })
+                .sum();
+
+        if (totalAttendance == 0) return 0.0;
+
+        return NumberUtil.round(2, totalAttendance / totalMeetings * 100);
+    }
+
+    @Transactional(readOnly = true)
+    public double calculateMembersAttendanceRateForStudy(Long avatarId, Long studyId) {
+        List<Proof> proofsForJoinedStudies = proofReader.findByAvatarIdAndStudyIdForJoinedStudy(avatarId, studyId);
+        List<Proof> proofsForLeftStudies = proofReader.findByAvatarIdAndStudyIdForLeftStudy(avatarId, studyId);
+
+        long totalMeetings = meetingReader.findMeetingsByStudyId(studyId).size();
+
+        double totalProof = Stream.concat(
+                        proofsForJoinedStudies.stream(),
+                        proofsForLeftStudies.stream()
+                )
+                .mapToDouble(proof -> {
+                    double reflectionRate = proof.getStatus().getReflectionRate();
+
+                    if (proofsForLeftStudies.contains(proof)) {
+                        reflectionRate *= EnrollmentStatus.LEFT.getReflectionRate();
+                    }
+
+                    return reflectionRate;
+                })
+                .sum();
+
+        if (totalProof == 0) {
+            return 0.0;
+        }
+
+        return NumberUtil.round(2, totalProof / totalMeetings * 100);
     }
 }

--- a/src/main/java/com/join/core/proof/service/ProofRateService.java
+++ b/src/main/java/com/join/core/proof/service/ProofRateService.java
@@ -1,5 +1,6 @@
 package com.join.core.proof.service;
 
+import com.join.core.common.util.NumberUtil;
 import com.join.core.enrollment.constant.EnrollmentStatus;
 import com.join.core.meeting.domain.MeetingReader;
 import com.join.core.proof.domain.Proof;
@@ -18,7 +19,7 @@ public class ProofRateService {
     private final ProofReader proofReader;
 
     @Transactional(readOnly = true)
-    public double calculateProofRate(Long avatarId) {
+    public double calculateIndividualProofRate(Long avatarId) {
         List<Proof> proofsForJoinedStudies = proofReader.findProofsByAvatarIdForJoinedStudies(avatarId);
         List<Proof> proofsForLeftStudies = proofReader.findProofsByAvatarIdForLeftStudies(avatarId);
 
@@ -43,6 +44,7 @@ public class ProofRateService {
             return 0.0;
         }
 
-        return totalProof / totalMeetings * 100;
+        return NumberUtil.round(2, totalProof / totalMeetings * 100);
+    }
     }
 }

--- a/src/main/java/com/join/core/proof/service/ProofReader.java
+++ b/src/main/java/com/join/core/proof/service/ProofReader.java
@@ -12,4 +12,9 @@ public interface ProofReader {
     List<Proof> findProofsByAvatarIdForJoinedStudies(Long avatarId);
     List<Proof> findProofsByAvatarIdForLeftStudies(Long avatarId);
     Proof getProofById(Long proofId);
+    List<Proof> findByStudyIdForJoinedStudy(Long studyId);
+    List<Proof> findByStudyIdForLeftStudy(Long studyId);
+    List<Proof> findByAvatarIdAndStudyIdForJoinedStudy(Long avatarId, Long studyId);
+    List<Proof> findByAvatarIdAndStudyIdForLeftStudy(Long avatarId, Long studyId);
+    boolean isFullyApproved(Long avatarId, Long studyId);
 }

--- a/src/main/java/com/join/core/study/domain/Study.java
+++ b/src/main/java/com/join/core/study/domain/Study.java
@@ -116,6 +116,8 @@ public class Study {
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudySchedule> schedules;
 
+    private String kakaoUrl;
+
     public Study(StudyRecruitRequest recruitRequest, Avatar writer, Address address, Category category) {
         if (writer == null)
             throw new InvalidParamException(INVALID_PARAMETER, "Study.writer");

--- a/src/main/java/com/join/core/study/repository/StudyQueryRepository.java
+++ b/src/main/java/com/join/core/study/repository/StudyQueryRepository.java
@@ -1,5 +1,6 @@
 package com.join.core.study.repository;
 
+import com.join.core.enrollment.constant.StudyRole;
 import com.join.core.study.domain.Study;
 import com.join.core.study.repository.condition.CustomStudyCondition;
 import com.join.core.study.repository.condition.EssentialStudyCondition;
@@ -14,4 +15,5 @@ public interface StudyQueryRepository {
     Page<Study> getStudiesOrderByPopularity(EssentialStudyCondition condition, LocalDateTime now, Pageable pageable);
     List<Study> getStudiesOrderByRecommendations(EssentialStudyCondition essentialStudyCondition, CustomStudyCondition customStudyCondition);
     boolean existsByEnrollmentsAvatarToken(String subjectToken, String targetToken);
+    List<Study> findAllByAvatarIdAndRole(Long avatarId, StudyRole status);
 }

--- a/src/main/java/com/join/core/study/repository/StudyQueryRepositoryImpl.java
+++ b/src/main/java/com/join/core/study/repository/StudyQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.join.core.study.repository;
 
 import com.join.core.enrollment.constant.EnrollmentStatus;
 import com.join.core.study.constant.StudyStatus;
+import com.join.core.enrollment.constant.StudyRole;
 import com.join.core.study.domain.Study;
 import com.join.core.study.repository.condition.CustomStudyCondition;
 import com.join.core.study.repository.condition.EssentialStudyCondition;
@@ -119,4 +120,14 @@ public class StudyQueryRepositoryImpl implements StudyQueryRepository {
                 .fetchFirst() != null;
     }
 
+
+    @Override
+    public List<Study> findAllByAvatarIdAndRole(Long avatarId, StudyRole status) {
+        return queryFactory.selectFrom(study)
+                .leftJoin(enrollment).on(
+                        enrollment.avatar.id.eq(avatarId),
+                        enrollment.role.eq(status)
+                )
+                .fetch();
+    }
 }

--- a/src/main/java/com/join/core/study/repository/StudyReaderImpl.java
+++ b/src/main/java/com/join/core/study/repository/StudyReaderImpl.java
@@ -3,6 +3,7 @@ package com.join.core.study.repository;
 import com.join.core.common.exception.ErrorCode;
 import com.join.core.common.exception.impl.EntityNotFoundException;
 import com.join.core.common.exception.impl.InvalidStateException;
+import com.join.core.enrollment.constant.StudyRole;
 import com.join.core.study.domain.Study;
 import com.join.core.study.repository.condition.CustomStudyCondition;
 import com.join.core.study.repository.condition.EssentialStudyCondition;
@@ -47,6 +48,11 @@ public class StudyReaderImpl implements StudyReader {
     @Override
     public List<Study> getStudiesOrderByRecommendations(EssentialStudyCondition condition, CustomStudyCondition customStudyCondition) {
         return studyQueryRepository.getStudiesOrderByRecommendations(condition, customStudyCondition);
+    }
+
+    @Override
+    public List<Study> getStudiesByLeaderAvatarId(Long avatarId) {
+        return studyQueryRepository.findAllByAvatarIdAndRole(avatarId, StudyRole.LEADER);
     }
 
     @Override

--- a/src/main/java/com/join/core/study/service/StudyReader.java
+++ b/src/main/java/com/join/core/study/service/StudyReader.java
@@ -14,6 +14,7 @@ public interface StudyReader {
     Study getStudyById(Long studyId);
     Page<Study> getStudyOrderByPopularity(EssentialStudyCondition condition, LocalDateTime now, Pageable pageable);
     List<Study> getStudiesOrderByRecommendations(EssentialStudyCondition condition, CustomStudyCondition customStudyCondition);
+    List<Study> getStudiesByLeaderAvatarId(Long avatarId);
     Page<Study> getStudiesByTitleContaining(String keyword, Pageable pageable);
     Study validateStudyCompletion(Long studyId);
     boolean existsByEnrollmentsAvatarToken(String subjectToken, String targetToken);

--- a/src/main/resources/application-swagger.yml
+++ b/src/main/resources/application-swagger.yml
@@ -13,3 +13,4 @@ swagger:
     proof: '11. 회차 인증'
     evaluation: '12. 평가'
     block: '13. 차단'
+    my-page: '14. 마이페이지'


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #88 

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
시작할 때의 생각보다 필요한 로직이 많아서 많이 두꺼워 진 것 같네요. 화면단위로 나눌 걸 그랬나 싶기도하네요 ㅠㅠ


- 운영중인 스터디 목록 추가
- 스터디 전체의 출석율, 인증율 계산
- 스터디원 각각의 출석율, 인증율 계산
- 스터디원이 모든 인증을 확인 받았는 지 확인

- Study 컬럼 추가 : kakaoUrl - figma에 있어 추가하였습니다.

- 기존 mypage 로직 일부 수정

## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- 테스트를 진행하였으나 탈퇴, 승인 탈퇴 등의 변수가 많아서 놓친 부분이 있는지 추후에 한번 더 확인해야 안전할 것 같습니다!

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
