### PR TITLE
[Bug] 스터디 모집 시 주소 검증 로직 변경

### DIFF
--- a/src/main/java/com/join/core/address/domain/Address.java
+++ b/src/main/java/com/join/core/address/domain/Address.java
@@ -30,4 +30,9 @@ public class Address {
 	@NotNull
 	private String city;
 
+	public Address(String province, String city) {
+		this.province = province;
+		this.city = city;
+	}
+
 }

--- a/src/main/java/com/join/core/address/repository/AddressReaderImpl.java
+++ b/src/main/java/com/join/core/address/repository/AddressReaderImpl.java
@@ -2,8 +2,6 @@ package com.join.core.address.repository;
 
 import com.join.core.address.domain.Address;
 import com.join.core.address.service.AddressReader;
-import com.join.core.common.exception.ErrorCode;
-import com.join.core.common.exception.impl.InvalidSelectionException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +16,7 @@ public class AddressReaderImpl implements AddressReader {
     @Override
     public Address getAddressByLocation(String province, String city) {
         return addressRepository.findByProvinceAndCity(province, city)
-                .orElseThrow(() -> new InvalidSelectionException(ErrorCode.ADDRESS_SELECTION_REQUIRED));
+                .orElseGet(() -> addressRepository.save(new Address(province, city)));
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #98 

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
[기존] 스터디 모집 시 주소 검증 로직이 기존에는 DB에 저장된 주소만 선택 가능
[변경] 입력한 주소가 DB에 없는 경우 자동으로 추가 & DB에 있는 경우 추가 안 되도록 변경
=> 기존의 `주소를 선택할 수 없음` 오류가 발생하지 않도록 변경하였습니다. 

## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
